### PR TITLE
Improve stage 5 UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor = "#2d7dd2"
+backgroundColor = "#f5f5f5"
+secondaryBackgroundColor = "#e0e0e0"
+textColor = "#000000"
+font = "sans serif"

--- a/stage 5/GUI/stage5.py
+++ b/stage 5/GUI/stage5.py
@@ -79,7 +79,8 @@ class Account(Base):
     customer_id     = Column(String(20), nullable=False)
     account_num     = Column(String(30), unique=True, nullable=False)
     opening_date    = Column(Date)
-    current_balance = Column(Numeric(14, 2))
+    # Database column is named "current_balan" (typo). Map attribute accordingly.
+    current_balance = Column("current_balan", Numeric(14, 2))
     status          = Column(String(10))
     account_type    = Column(String(20))
 

--- a/stage 5/GUI/stage5.py
+++ b/stage 5/GUI/stage5.py
@@ -68,6 +68,22 @@ class Check(Base):
     transaction     = relationship("Transaction", back_populates="checks")
 
 
+class Account(Base):
+    __tablename__ = "account"
+    account_id      = Column(
+        Integer,
+        Sequence('account_id_seq'),
+        primary_key=True,
+        server_default=Sequence('account_id_seq').next_value()
+    )
+    customer_id     = Column(String(20), nullable=False)
+    account_num     = Column(String(30), unique=True, nullable=False)
+    opening_date    = Column(Date)
+    current_balance = Column(Numeric(14, 2))
+    status          = Column(String(10))
+    account_type    = Column(String(20))
+
+
 # 4) Créer les tables si on lance ce script directement
 if __name__ == "__main__":
     Base.metadata.create_all(engine)

--- a/stage 5/GUI/streamlit_app.py
+++ b/stage 5/GUI/streamlit_app.py
@@ -2,7 +2,24 @@ import streamlit as st
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
-from stage5 import Transaction, Transfer, Check, Session
+from stage5 import Transaction, Transfer, Check, Account, Session
+
+st.set_page_config(
+    page_title="Gestion Transactions",
+    page_icon="🏦",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.markdown(
+    """
+    <style>
+    .stButton>button {border-radius:5px;}
+    .stTextInput>div>div>input {border-radius:5px;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # --- PARAMÈTRES D'AUTHENTIFICATION ---
 VALID_USERNAME = "ruben"
@@ -14,24 +31,30 @@ if 'logged_in' not in st.session_state:
 
 # Écran de connexion
 if not st.session_state['logged_in']:
-    st.title("🔐 Connexion requise")
-    username = st.text_input("Nom d'utilisateur")
-    password = st.text_input("Mot de passe", type="password")
-    if st.button("Se connecter"):
-        if username == VALID_USERNAME and password == VALID_PASSWORD:
-            st.session_state['logged_in'] = True
-        else:
-            st.error("Identifiants invalides")
+    st.markdown("<h2 style='text-align:center'>🔐 Connexion requise</h2>", unsafe_allow_html=True)
+    col1, col2, col3 = st.columns([1, 2, 1])
+    with col2:
+        with st.form("login_form"):
+            username = st.text_input("Nom d'utilisateur")
+            password = st.text_input("Mot de passe", type="password")
+            if st.form_submit_button("Se connecter"):
+                if username == VALID_USERNAME and password == VALID_PASSWORD:
+                    st.session_state['logged_in'] = True
+                else:
+                    st.error("Identifiants invalides")
     st.stop()  # arrête l'exécution tant que l'utilisateur n'est pas connecté
 
 # Configuration de la page (après authentification)
-st.set_page_config(page_title="Gestion Transactions", layout="wide")
+st.title("🏦 Gestion des Transactions")
 tab_crud, tab_reports = st.tabs(["CRUD", "Rapports"])
 
 
 # === ONGLET CRUD ===
 with tab_crud:
-    table = st.sidebar.selectbox("Sélectionner la table", ["Transaction", "Transfer", "Check"])
+    table = st.sidebar.selectbox(
+        "Sélectionner la table",
+        ["Transaction", "Transfer", "Check", "Account"]
+    )
     key = table if table == "Transaction" else table.lower()
     st.header(f"Gérer les {table}s")
 
@@ -71,6 +94,20 @@ with tab_crud:
                     "issue_date":      r.issue_date,
                     "clearance_date":  r.clearance_date
                 } for r in rows])
+
+            elif table_name == "account":
+                rows = session.query(Account).all()
+                return pd.DataFrame([
+                    {
+                        "account_id":      r.account_id,
+                        "customer_id":     r.customer_id,
+                        "account_num":     r.account_num,
+                        "opening_date":    r.opening_date,
+                        "current_balance": float(r.current_balance) if r.current_balance is not None else None,
+                        "status":          r.status,
+                        "account_type":    r.account_type
+                    } for r in rows
+                ])
 
         return pd.DataFrame()
 
@@ -239,6 +276,57 @@ with tab_crud:
                 session.rollback()
                 st.error("Suppression impossible : contraintes FK")
 
+    def add_account(customer_id, account_num, opening_date, current_balance, status, account_type):
+        with Session() as session:
+            try:
+                acc = Account(
+                    customer_id=customer_id,
+                    account_num=account_num,
+                    opening_date=opening_date,
+                    current_balance=current_balance,
+                    status=status,
+                    account_type=account_type
+                )
+                session.add(acc)
+                session.commit()
+                st.success("Account ajouté")
+            except Exception as e:
+                session.rollback()
+                st.error(f"Erreur ajout Account : {e}")
+
+    def update_account(acc_id, customer_id, account_num, opening_date, current_balance, status, account_type):
+        with Session() as session:
+            acc = session.get(Account, int(acc_id))
+            if not acc:
+                st.error("Account non trouvé")
+                return
+            try:
+                acc.customer_id     = customer_id
+                acc.account_num     = account_num
+                acc.opening_date    = opening_date
+                acc.current_balance = current_balance
+                acc.status          = status
+                acc.account_type    = account_type
+                session.commit()
+                st.success("Account mise à jour")
+            except Exception as e:
+                session.rollback()
+                st.error(f"Erreur mise à jour Account : {e}")
+
+    def delete_account(acc_id):
+        with Session() as session:
+            acc = session.get(Account, int(acc_id))
+            if not acc:
+                st.error("Account non trouvé")
+                return
+            try:
+                session.delete(acc)
+                session.commit()
+                st.success("Account supprimé")
+            except IntegrityError:
+                session.rollback()
+                st.error("Suppression impossible : contraintes FK")
+
     # Formulaires CRUD
     if table == "Transaction":
         with st.expander("➕ Ajouter Transaction"):
@@ -297,6 +385,36 @@ with tab_crud:
             tr_id_del = st.number_input("Transfer ID à supprimer", min_value=1, key="del_tr_id")
             if st.button("Supprimer Transfer"):
                 delete_transfer(tr_id_del)
+
+    elif table == "Account":
+        with st.expander("➕ Ajouter Account"):
+            data = {
+                'customer_id':     st.text_input("Customer ID"),
+                'account_num':     st.text_input("Account Number"),
+                'opening_date':    st.date_input("Opening Date"),
+                'current_balance': st.number_input("Current Balance", format="%.2f"),
+                'status':          st.text_input("Status"),
+                'account_type':    st.text_input("Account Type")
+            }
+            if st.button("Ajouter Account"):
+                add_account(**data)
+
+        with st.expander("✏ Mettre à jour Account"):
+            with st.form("update_acc_form"):
+                acc_id         = st.number_input("Account ID", min_value=1, key="upd_acc_id")
+                customer_id    = st.text_input("Customer ID", key="upd_cust")
+                account_num    = st.text_input("Account Number", key="upd_acc_num")
+                opening_date   = st.date_input("Opening Date", key="upd_open")
+                current_balance = st.number_input("Current Balance", format="%.2f", key="upd_bal")
+                status         = st.text_input("Status", key="upd_status")
+                account_type   = st.text_input("Account Type", key="upd_acc_type")
+                if st.form_submit_button("Mettre à jour Account"):
+                    update_account(acc_id, customer_id, account_num, opening_date, current_balance, status, account_type)
+
+        with st.expander("🗑 Supprimer Account"):
+            acc_id_del = st.number_input("Account ID à supprimer", min_value=1, key="del_acc_id")
+            if st.button("Supprimer Account"):
+                delete_account(acc_id_del)
 
     else:  # Check
         with st.expander("➕ Ajouter Check"):


### PR DESCRIPTION
## Summary
- add Streamlit theme configuration
- revamp login screen with centered form and page icon
- modernize header layout
- add account table model
- CRUD UI for account management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68642c1e3314832699ff16ef570250b0